### PR TITLE
解决AndroidManifest.xml里注释有中文 或 “-->”前没有空格时 出错的bug

### DIFF
--- a/Gradle/build.gradle
+++ b/Gradle/build.gradle
@@ -71,7 +71,7 @@ android.applicationVariants.all{ variant ->
             into("${buildDir}/manifests/$variant.name")
 
             filter{
-                String line -> line.replaceAll("UMENG_CHANNEL_VALUE", "${variant.productFlavors[0].name}")
+                String line -> line.replaceAll("UMENG_CHANNEL_VALUE", "${variant.productFlavors[0].name}").replaceAll("<!--.*?-->", "")
             }
 
             variant.processResources.manifestFile = file("${buildDir}/manifests/${variant.name}/${variant.dirName}/AndroidManifest.xml")


### PR DESCRIPTION
本commit解决的问题描述：（本人已十分确定自己的AndroidManifest.xml是UTF-8 并且gradle设置了options.encoding = "UTF-8"）
1、<!--注释先后没有加空格--> 此时 会报错org.xml.sax.SAXParseException: The string "--" is not permitted within comments.   解决方法也可以<!-- 注释先后都加空格 -->
2、注释中有中文时，copy 到的AndroidManifest.xml里面中文会变成乱码，gradle构建就会出错： error: Error parsing XML: not well-formed (invalid token)。

我的解决方法很简单，就是把临时的AndroidManifest.xml中的注释用正则删掉即可。亲测可行，望作者采纳，谢谢。
