### PR TITLE
fix crash bug of build-tool v21

### DIFF
--- a/VSProject/CommonTools/DecodedApkStruct.cs
+++ b/VSProject/CommonTools/DecodedApkStruct.cs
@@ -89,9 +89,18 @@ namespace CommonTools
 
                 var attr_version = doc.DocumentElement.Attributes;
 
-                
-                VersionName = fetchString(attr_version["android:versionName"].Value);
-                VersionCode = fetchString(attr_version["android:versionCode"].Value);
+                // fix crash bug of build-tool v21
+                try
+                {
+                    VersionName = fetchString(attr_version["android:versionName"].Value);
+                    VersionCode = fetchString(attr_version["android:versionCode"].Value);
+                }
+                catch (Exception e)
+                {
+                    // because with build-tool v21, there are not VersionName and VersionCode in AndroidManifest.xml
+                    VersionName = "0";
+                    VersionCode = "0";
+                }
 
                 var application = doc.GetElementsByTagName("application")[0];
                 var attr_app = application.Attributes;


### PR DESCRIPTION
because with build-tool v21, there are not VersionName and VersionCode in AndroidManifest.xml
i just add try-catch with the fetchString() method

also, you need to change the apktool version to 2.0.0+, in this path:
~/VSProject / UmengTools / tools / apktool 

 you can check it out here:
https://bitbucket.org/iBotPeaches/apktool/downloads
# 

or, you can specify the build-tool below v21
check it out here:
https://developer.android.com/tools/revisions/build-tools.html
