### PR TITLE
支持Gradle 2.2

### DIFF
--- a/Gradle/for1.11_build.gradle
+++ b/Gradle/for1.11_build.gradle
@@ -111,21 +111,20 @@ tasks.withType(Compile) {
     options.encoding = "UTF-8"
 }
 
-//替换AndroidManifest.xml的UMENG_CHANNEL_VALUE字符串为渠道名称 By Remex Huang
-android.applicationVariants.all{ variant -> 
-    variant.processManifest.doLast{
-    
-        //之前这里用的copy{}，我换成了文件操作，这样可以在v1.11版本正常运行，并保持文件夹整洁
-        //${buildDir}是指./build文件夹
-        //${variant.dirName}是flavor/buildtype，例如GooglePlay/release，运行时会自动生成
-        //下面的路径是类似这样：./build/manifests/GooglePlay/release/AndroidManifest.xml
-        def manifestFile = "${buildDir}/manifests/${variant.dirName}/AndroidManifest.xml"
-        
-        //将字符串UMENG_CHANNEL_VALUE替换成flavor的名字
-        def updatedContent = new File(manifestFile).getText('UTF-8').replaceAll("UMENG_CHANNEL_VALUE", "${variant.productFlavors[0].name}")
-        new File(manifestFile).write(updatedContent, 'UTF-8')
-        
-        //将此次flavor的AndroidManifest.xml文件指定为我们修改过的这个文件
-        variant.processResources.manifestFile = file("${buildDir}/manifests/${variant.dirName}/AndroidManifest.xml")
-    }    
+//替换AndroidManifest.xml的UMENG_CHANNEL_VALUE字符串为渠道名称 By Jason Yu
+applicationVariants.all{ variant ->
+    variant.outputs.each{ output->
+        output.processManifest.doLast{
+            //${buildDir}是指./build文件夹
+            def manifestFile = "${buildDir}/intermediates/manifests/full/${variant.dirName}/AndroidManifest.xml"
+                    
+            //将字符串UMENG_CHANNEL_VALUE替换成flavor的名字
+            def updatedContent = new File(manifestFile).getText('UTF-8').replaceAll("UMENG_CHANNEL_VALUE", "${variant.productFlavors[0].name}")
+            new File(manifestFile).write(updatedContent, 'UTF-8')
+            
+            //不需要再次指定
+            //variant.processResources.manifestFile = file("${buildDir}/manifests/${variant.dirName}/AndroidManifest.xml")
+
+        }
+    }
 }


### PR DESCRIPTION
根据 http://stackoverflow.com/questions/27302965/could-not-find-property-processmanifest-on-com-android-build-gradle-internal-a  更新更改AndroidManifest.xml方法

根据 http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits 了解到 getProcessManifest方法属于VariantOutput，通过variant.outputs可以获取到。

在以下环境测试成功：
compileSdkVersion 21
buildToolsVersion "21.1.2"
classpath 'com.android.tools.build:gradle:1.0.0'